### PR TITLE
Remove guardrails for search

### DIFF
--- a/core_backend/app/question_answer/routers.py
+++ b/core_backend/app/question_answer/routers.py
@@ -340,7 +340,7 @@ async def voice_search(
             generate_tts=True,
         )
 
-        response = await get_search_response(
+        response = await get_search_response_llm(
             query_refined=user_query_refined_template,
             response=response_template,
             user_id=user_db.user_id,


### PR DESCRIPTION
Reviewer: @tonyzhao6 
Estimate: 20mins

---

## Ticket

Fixes:

## Description

### Goal
MomConnect currently doesn't support LLMs for search. This PR update the search logic to use guardrails only for chat and do the search without guardrails
### Changes
- Added a get_search_response_llm function with guardrail and used a contextvar to call get_search_response_llm in `/chat` and `get_search_response` in `/search`
### Future Tasks (optional)

## How has this been tested?
- Ran tests and tested manually to make sure /search doesn't call guardrails
## To-do before merge (optional)

## Checklist

Fill with `x` for completed. 

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts

(Delete any items below that are not relevant)
- [ ] I have updated the automated tests
- [ ] I have updated the scripts in `scripts/`
- [ ] I have updated the requirements
- [ ] I have updated the README file
- [ ] I have updated affected documentation
- [ ] I have added a blogpost in Latest Updates
- [ ] I have updated the CI/CD scripts in `.github/workflows/`
- [ ] I have updated the Terraform code
